### PR TITLE
update postfixadmin to 3.2.3 + remove asc gpg checking

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN echo "@community https://nl.alpinelinux.org/alpine/v3.11/community" >> /etc/
  && wget -q https://github.com/postfixadmin/postfixadmin/archive/${PFA_TARBALL} \
  && CHECKSUM=$(sha256sum ${PFA_TARBALL} | awk '{print $1}') \
  && if [ "${CHECKSUM}" != "${SHA256_HASH}" ]; then echo "ERROR: Checksum does not match!" && exit 1; fi \
- && mkdir /postfixadmin && tar xzf ${PFA_TARBALL} -C /postfixadmin && mv /postfixadmin/postfixadmin-$VERSION/* /postfixadmin \
+ && mkdir /postfixadmin && tar xzf ${PFA_TARBALL} -C /postfixadmin && mv /postfixadmin/postfixadmin-postfixadmin-$VERSION/* /postfixadmin \
  && apk del build-dependencies \
  && rm -rf /var/cache/apk/* /tmp/* /root/.gnupg /postfixadmin/postfixadmin-$VERSION*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,13 +3,8 @@ FROM alpine:3.11.3
 LABEL description "PostfixAdmin is a web based interface used to manage mailboxes" \
       maintainer="Hardware <contact@meshup.net>"
 
-ARG VERSION=3.2
-
-# https://pgp.mit.edu/pks/lookup?search=0xC6A682EA63C82F1C&fingerprint=on&op=index
-# pub  4096R/63C82F1C 2005-10-06 Christian Boltz (www.cboltz.de) <gpg@cboltz.de>
-ARG GPG_SHORTID="0xC6A682EA63C82F1C"
-ARG GPG_FINGERPRINT="70CA A060 DE04 2AAE B1B1  5196 C6A6 82EA 63C8 2F1C"
-ARG SHA256_HASH="866d4c0ca870b2cac184e5837a4d201af8fcefecef09bc2c887a6e017a00cefe"
+ARG VERSION=3.2.3
+ARG SHA256_HASH="dae88f8166804997386bdf2454a62afc9bc768f0e4b53f46003d2766cebf31c0"
 
 RUN echo "@community https://nl.alpinelinux.org/alpine/v3.11/community" >> /etc/apk/repositories \
  && apk -U upgrade \
@@ -30,18 +25,9 @@ RUN echo "@community https://nl.alpinelinux.org/alpine/v3.11/community" >> /etc/
     php7-mbstring@community \
  && cd /tmp \
  && PFA_TARBALL="postfixadmin-${VERSION}.tar.gz" \
- && wget -q https://downloads.sourceforge.net/project/postfixadmin/postfixadmin/postfixadmin-${VERSION}/${PFA_TARBALL} \
- && wget -q https://downloads.sourceforge.net/project/postfixadmin/postfixadmin/postfixadmin-${VERSION}/${PFA_TARBALL}.asc \
- && ( \
-    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys ${GPG_SHORTID} || \
-    gpg --keyserver keyserver.pgp.com --recv-keys ${GPG_SHORTID} || \
-    gpg --keyserver pgp.mit.edu --recv-keys ${GPG_SHORTID} \
-    ) \
+ && wget -q https://github.com/postfixadmin/postfixadmin/archive/${PFA_TARBALL} \
  && CHECKSUM=$(sha256sum ${PFA_TARBALL} | awk '{print $1}') \
  && if [ "${CHECKSUM}" != "${SHA256_HASH}" ]; then echo "ERROR: Checksum does not match!" && exit 1; fi \
- && FINGERPRINT="$(LANG=C gpg --verify ${PFA_TARBALL}.asc ${PFA_TARBALL} 2>&1 | sed -n "s#Primary key fingerprint: \(.*\)#\1#p")" \
- && if [ -z "${FINGERPRINT}" ]; then echo "ERROR: Invalid GPG signature!" && exit 1; fi \
- && if [ "${FINGERPRINT}" != "${GPG_FINGERPRINT}" ]; then echo "ERROR: Wrong GPG fingerprint!" && exit 1; fi \
  && mkdir /postfixadmin && tar xzf ${PFA_TARBALL} -C /postfixadmin && mv /postfixadmin/postfixadmin-$VERSION/* /postfixadmin \
  && apk del build-dependencies \
  && rm -rf /var/cache/apk/* /tmp/* /root/.gnupg /postfixadmin/postfixadmin-$VERSION*


### PR DESCRIPTION
asc gpg checking removed because they just tag their versions now and don't provide an asc anymore.