### PR TITLE
Update postfixadmin 3.3.4, update alpine:3.13 and php8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ FROM alpine:3.12
 LABEL description="PostfixAdmin is a web based interface used to manage mailboxes" \
     maintainer="Hardware <contact@meshup.net>"
 
-ARG VERSION=3.2.4
-ARG SHA256_HASH="f61a64b32052c46f40cba466e5e384de0efab8c343c91569bcc5ebfd3694811e"
+ARG VERSION=3.3.1
+ARG SHA256_HASH="5dff072ce6e00558281809c1abeb4000a9d32bd5b4751fd55cb966b003cbcaf3"
 
 RUN set -eux; \
     apk add --no-cache \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ FROM alpine:3.12
 LABEL description="PostfixAdmin is a web based interface used to manage mailboxes" \
     maintainer="Hardware <contact@meshup.net>"
 
-ARG VERSION=3.3.1
-ARG SHA256_HASH="5dff072ce6e00558281809c1abeb4000a9d32bd5b4751fd55cb966b003cbcaf3"
+ARG VERSION=3.3.2
+ARG SHA256_HASH="9d9ed67405bb717d41024e2c0e7ba3acecd3f1b977b4d95ab7211bbfc623908d"
 
 RUN set -eux; \
     apk add --no-cache \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.12
+FROM alpine:3.13
 
 LABEL description="PostfixAdmin is a web based interface used to manage mailboxes" \
     maintainer="Hardware <contact@meshup.net>"
@@ -12,17 +12,17 @@ RUN set -eux; \
         dovecot \
         tini \
         \
-        php7 \
-        php7-fpm \
-        php7-imap \
-        php7-mbstring \
-        php7-mysqli \
-        php7-pdo \
-        php7-pdo_mysql \
-        php7-pdo_pgsql \
-        php7-pgsql \
-        php7-phar \
-        php7-session \
+        php8 \
+        php8-fpm \
+        php8-imap \
+        php8-mbstring \
+        php8-mysqli \
+        php8-pdo \
+        php8-pdo_mysql \
+        php8-pdo_pgsql \
+        php8-pgsql \
+        php8-phar \
+        php8-session \
     ; \
     \
     PFA_TARBALL="postfixadmin-${VERSION}.tar.gz"; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,8 @@ RUN set -eux; \
         php7-mbstring \
         php7-mysqli \
         php7-pdo \
+        php7-pdo_mysql \
+        php7-pdo_pgsql \
         php7-pgsql \
         php7-phar \
         php7-session \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ FROM alpine:3.13
 LABEL description="PostfixAdmin is a web based interface used to manage mailboxes" \
     maintainer="Hardware <contact@meshup.net>"
 
-ARG VERSION=3.3.2
-ARG SHA256_HASH="9d9ed67405bb717d41024e2c0e7ba3acecd3f1b977b4d95ab7211bbfc623908d"
+ARG VERSION=3.3.3
+ARG SHA256_HASH="e9cdfcba7d69d0dbab1db0203f9bcc93a712d2cfeb1b5259625b69b4ec7403c4"
 
 RUN set -eux; \
     apk add --no-cache \

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN set -eux; \
         php7-imap \
         php7-mbstring \
         php7-mysqli \
+        php7-pdo \
         php7-pgsql \
         php7-phar \
         php7-session \

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,8 @@ RUN set -eux; \
     \
     mkdir /postfixadmin; \
     tar -xzf ${PFA_TARBALL} --strip-components=1 -C /postfixadmin; \
-    rm -f ${PFA_TARBALL}
+    rm -f ${PFA_TARBALL}; \
+    chmod 644 /etc/ssl/dovecot/server.key
 
 COPY bin /usr/local/bin
 RUN chmod +x /usr/local/bin/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ FROM alpine:3.13
 LABEL description="PostfixAdmin is a web based interface used to manage mailboxes" \
     maintainer="Hardware <contact@meshup.net>"
 
-ARG VERSION=3.3.3
-ARG SHA256_HASH="e9cdfcba7d69d0dbab1db0203f9bcc93a712d2cfeb1b5259625b69b4ec7403c4"
+ARG VERSION=3.3.4
+ARG SHA256_HASH="8720ab6945d6526abffb18e8c5cb0f33a4fe884aa03749d55f0707e45f92b7eb"
 
 RUN set -eux; \
     apk add --no-cache \

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ PostfixAdmin is a web based interface used to manage mailboxes, virtual domains 
 
 - Lightweight & secure image (no root process)
 - Based on Alpine Linux
-- Latest Postfixadmin version (3.3.3)
+- Latest Postfixadmin version (3.3.4)
 - MariaDB/PostgreSQL driver
 - With PHP8
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ PostfixAdmin is a web based interface used to manage mailboxes, virtual domains 
 
 - Lightweight & secure image (no root process)
 - Based on Alpine Linux
-- Latest Postfixadmin version (3.3.2)
+- Latest Postfixadmin version (3.3.3)
 - MariaDB/PostgreSQL driver
 - With PHP7
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![postfixadmin](http://i.imgur.com/UCtvKHR.png "postfixadmin")
 
-### What is this ?
+### What is this?
 
 PostfixAdmin is a web based interface used to manage mailboxes, virtual domains and aliases. It also features support for vacation/out-of-the-office messages.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ PostfixAdmin is a web based interface used to manage mailboxes, virtual domains 
 
 - Lightweight & secure image (no root process)
 - Based on Alpine Linux
-- Latest Postfixadmin version (3.2)
+- Latest Postfixadmin version (3.3.2)
 - MariaDB/PostgreSQL driver
 - With PHP7
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ PostfixAdmin is a web based interface used to manage mailboxes, virtual domains 
 - Based on Alpine Linux
 - Latest Postfixadmin version (3.3.3)
 - MariaDB/PostgreSQL driver
-- With PHP7
+- With PHP8
 
 ### Built-time variables
 

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -91,4 +91,4 @@ cat > /postfixadmin/config.local.php <<EOF
 EOF
 
 # RUN !
-exec su-exec $UID:$GID php7 -S 0.0.0.0:8888 -t /postfixadmin/public
+exec su-exec $UID:$GID php8 -S 0.0.0.0:8888 -t /postfixadmin/public

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -90,5 +90,7 @@ cat > /postfixadmin/config.local.php <<EOF
 ?>
 EOF
 
+# Upgrade
+php8 /postfixadmin/public/upgrade.php
 # RUN !
 exec su-exec $UID:$GID php8 -S 0.0.0.0:8888 -t /postfixadmin/public

--- a/bin/setup
+++ b/bin/setup
@@ -10,7 +10,7 @@ read -rp "> Postfixadmin setup hash : " HASH
 # MD5(salt) : SHA1( MD5(salt) : PASSWORD );
 #    32     1              40
 # Exemple : ffdeb741c58db80d060ddb170af4623a:54e0ac9a55d69c5e53d214c7ad7f1e3df40a3caa
-while [ ${#HASH} -ne 73 ]; do
+while [ ${#HASH} -ne 60 ]; do
   echo -e "${CRED}\n/!\ Invalid HASH !${CEND}" 1>&2
   read -rp "> Postfixadmin setup hash : " HASH
   echo ""

--- a/bin/setup
+++ b/bin/setup
@@ -7,9 +7,11 @@ CGREEN="${CSI}1;32m"
 
 read -rp "> Postfixadmin setup hash : " HASH
 
-# MD5(salt) : SHA1( MD5(salt) : PASSWORD );
-#    32     1              40
-# Exemple : ffdeb741c58db80d060ddb170af4623a:54e0ac9a55d69c5e53d214c7ad7f1e3df40a3caa
+# postfixadmin uses the function password_hash with PASSWORD_DEFAULT since version 3.3.0.
+# password_hash() creates a new password hash using a strong one-way hashing algorithm.
+# PASSWORD_DEFAULT - Use the bcrypt algorithm (default as of PHP 5.5.0). Note that this constant is designed to change over time as new and stronger algorithms are added to PHP.
+# PASSWORD_BCRYPT - Use the CRYPT_BLOWFISH algorithm to create the hash. This will produce a standard crypt() compatible hash using the "$2y$" identifier. The result will always be a 60 character string, or false on failure.
+# See also: https://www.php.net/manual/en/function.password-hash.php
 while [ ${#HASH} -ne 60 ]; do
   echo -e "${CRED}\n/!\ Invalid HASH !${CEND}" 1>&2
   read -rp "> Postfixadmin setup hash : " HASH


### PR DESCRIPTION
I have pushed a image build with these changes to [my docker hub](https://hub.docker.com/r/sarasmiseth/postfixadmin).

This is what I did so far.

I got the following error after using this updated image:

> ERROR: The PostfixAdmin database layout is outdated (you have r1840, but r1843 is expected). Please run setup.php to upgrade the database. 

To update I executed the following command.

``` shell
docker exec -ti docker_postfixadmin_1 php postfixadmin/public/upgrade.php
```

Now the login page loads fine. But after logging in I get this error:

```
postfixadmin_1  | [Wed Jan 13 15:37:04 2021] Failed to read password from /usr/bin/doveadm pw ... stderr: doveconf: Fatal: Error in configuration file /etc/dovecot/conf.d/10-ssl.conf line 16: ssl_key: Can't open file /etc/ssl/dovecot/server.key: Permission denied
postfixadmin_1  | , password:  
postfixadmin_1  | [Wed Jan 13 15:37:04 2021] PHP Fatal error:  Uncaught Exception: /usr/bin/doveadm pw failed, see error log for details in /postfixadmin/functions.inc.php:1056
postfixadmin_1  | Stack trace:
postfixadmin_1  | #0 /postfixadmin/functions.inc.php(1271): _pacrypt_dovecot('xnrM6g6gfVp8Aox...', '{SHA512-CRYPT}$...')
postfixadmin_1  | #1 /postfixadmin/model/Login.php(32): pacrypt('xnrM6g6gfVp8Aox...', '{SHA512-CRYPT}$...')
postfixadmin_1  | #2 /postfixadmin/public/login.php(63): Login->login('postfixadmin@m0...', 'xnrM6g6gfVp8Aox...')
postfixadmin_1  | #3 {main}
postfixadmin_1  |   thrown in /postfixadmin/functions.inc.php on line 1056
postfixadmin_1  | [Wed Jan 13 15:37:04 2021] 172.18.0.2:53756 [500]: /login.php - Uncaught Exception: /usr/bin/doveadm pw failed, see error log for details in /postfixadmin/functions.inc.php:1056
postfixadmin_1  | Stack trace:
postfixadmin_1  | #0 /postfixadmin/functions.inc.php(1271): _pacrypt_dovecot('xnrM6g6gfVp8Aox...', '{SHA512-CRYPT}$...')
postfixadmin_1  | #1 /postfixadmin/model/Login.php(32): pacrypt('xnrM6g6gfVp8Aox...', '{SHA512-CRYPT}$...')
postfixadmin_1  | #2 /postfixadmin/public/login.php(63): Login->login('postfixadmin@m0...', 'xnrM6g6gfVp8Aox...')
postfixadmin_1  | #3 {main}
postfixadmin_1  |   thrown in /postfixadmin/functions.inc.php on line 1056
```

It seems like the problem is caused by a newer dovecot version which was released in the meantime. This new version (/usr/bin/doveadm pw) tries to read /etc/ssl/dovecot/server.key but it has no permissions to do so.

`/usr/bin/doveadm pw` is used for the hashing of the password

Workaround, but not really the real fix is this:

``` shell
docker exec -ti docker_postfixadmin_1 chmod 777 /etc/ssl/dovecot/server.key
```

After running this I was able to login.