### PR TITLE
Update postfixadmin to 4.0.1 + alpine to 3.23

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,38 +1,50 @@
-FROM alpine:3.21
+FROM alpine:3.23
 
 LABEL description="PostfixAdmin is a web based interface used to manage mailboxes"
 
-ARG VERSION=3.3.14
-ARG PHP_VERSION=84
-ARG SHA256_HASH="bd48687431472dc1753513bdf38a498f6b913d3c04a8e4d6d2415d190760e5a3"
+ARG VERSION=4.0.1
+ARG SHA256_HASH="b0cf3a6e28d46581f25fd3db0547b45179dac39a9027c719da8d34319045fa8f"
 
 RUN set -eux; \
     apk update && apk upgrade; \
     apk add --no-cache \
+        bash \
         su-exec \
         dovecot \
         tini \
-        php${PHP_VERSION} \
-        php${PHP_VERSION}-fpm \
-        php${PHP_VERSION}-imap \
-        php${PHP_VERSION}-mbstring \
-        php${PHP_VERSION}-mysqli \
-        php${PHP_VERSION}-pdo \
-        php${PHP_VERSION}-pdo_mysql \
-        php${PHP_VERSION}-pdo_pgsql \
-        php${PHP_VERSION}-pgsql \
-        php${PHP_VERSION}-phar \
-        php${PHP_VERSION}-session \
+        \
+        php \
+        php-curl \
+        php-dom \
+        php-fpm \
+        php-iconv \
+        php-imap \
+        php-intl \
+        php-mbstring \
+        php-mysqli \
+        php-pdo \
+        php-pdo_mysql \
+        php-pdo_pgsql \
+        php-pgsql \
+        php-phar \
+        php-session \
+        php-simplexml \
+        php-sqlite3 \
+        php-tokenizer \
+        php-xml \
+        php-xmlwriter \
     ; \
     \
-    PFA_TARBALL="postfixadmin-${VERSION}.tar.gz"; \
+    PFA_TARBALL="v${VERSION}.tar.gz"; \
     wget -q https://github.com/postfixadmin/postfixadmin/archive/${PFA_TARBALL}; \
     echo "${SHA256_HASH} *${PFA_TARBALL}" | sha256sum -c; \
     \
     mkdir /postfixadmin; \
     tar -xzf ${PFA_TARBALL} --strip-components=1 -C /postfixadmin; \
     rm -f ${PFA_TARBALL}; \
-    chmod 644 /etc/ssl/dovecot/server.key
+    /bin/bash /postfixadmin/install.sh; \
+    ver="$(dovecot --version | awk '{print $1}')"; \
+    printf "dovecot_config_version = %s\ndovecot_storage_version = %s\n" "$ver" "$ver" > /etc/dovecot/dovecot.conf
 
 COPY bin /usr/local/bin
 RUN chmod +x /usr/local/bin/*

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -91,6 +91,6 @@ cat > /postfixadmin/config.local.php <<EOF
 EOF
 
 # Upgrade
-php84 /postfixadmin/public/upgrade.php
+php /postfixadmin/public/upgrade.php
 # RUN !
-exec su-exec $UID:$GID php84 -S 0.0.0.0:8888 -t /postfixadmin/public
+exec su-exec $UID:$GID php -S 0.0.0.0:8888 -t /postfixadmin/public


### PR DESCRIPTION
Base image alpine updated to 3.24
Postfixadmin updated to 4.0.1
Postfix GitHub releases page seems to have a different naming convetion form 4.0.1 release so this had to be updated too
Apparently now an install script needs to be run as per <https://github.com/postfixadmin/postfixadmin/issues/955>
The install script requires bash so it's added
The install script does not understand `php84` style binary and always requries `php` so the packages names to install had to change
The install script requries a whole lot of php extensions that were added
Dovecot no longer comes with default cert/key so reference to this is removed
Dovecot no longer comes with default configuration, so generating it is added
Dovecot is used by Postfixadming for password checking upon login. It is also used for quotas but this bit must have never worked with mailserver because we are not using the same dovecot instance.